### PR TITLE
Create Pitcher Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ po/*~
 
 # RStudio Connect folder
 rsconnect/
+
+data/

--- a/simulator/data_process.R
+++ b/simulator/data_process.R
@@ -2,6 +2,16 @@ library(tidyverse)
 
 sc <- read.csv('data/statcast.csv')
 
-sc_selected <- sc |> select(pitch_type, zone, type, bb_type, effective_speed, pitcher, batter, bat_score, fld_score, balls, strikes, outs_when_up, inning, inning_topbot)
+sc_selected <- sc |> select(pitch_type, zone, type, bb_type, effective_speed, pitcher, batter, bat_score, fld_score, balls, strikes, outs_when_up, inning, inning_topbot, events)
 
 write.csv(sc_selected, 'data/sc_selected.csv')
+
+sc_down <- sc_selected |>
+  mutate(fld_winning = (fld_score > bat_score),
+         pitcher = as.integer(pitcher)) |>
+  group_by(pitcher, fld_winning, inning, inning_topbot, outs_when_up, balls, strikes)
+
+pitcher_pitchtypes <- sc_down |>
+  drop_na(pitch_type) |>
+  count(pitch_type)
+  

--- a/simulator/data_process.R
+++ b/simulator/data_process.R
@@ -1,17 +1,37 @@
 library(tidyverse)
 
-sc <- read.csv('data/statcast.csv')
+sc <- read.csv("data/statcast.csv")
 
-sc_selected <- sc |> select(pitch_type, zone, type, bb_type, effective_speed, pitcher, batter, bat_score, fld_score, balls, strikes, outs_when_up, inning, inning_topbot, events)
+sc_selected <- sc |>
+  select(pitch_type, zone, type, bb_type, effective_speed, pitcher, batter, bat_score, fld_score, balls, strikes, outs_when_up, inning, inning_topbot, events) |>
+  mutate(
+    fld_winning = (fld_score > bat_score),
+    pitcher = as.integer(pitcher)
+  )
 
-write.csv(sc_selected, 'data/sc_selected.csv')
+write.csv(sc_selected, "data/sc_selected.csv")
 
-sc_down <- sc_selected |>
-  mutate(fld_winning = (fld_score > bat_score),
-         pitcher = as.integer(pitcher)) |>
-  group_by(pitcher, fld_winning, inning, inning_topbot, outs_when_up, balls, strikes)
+pitcher_pitchtypes <- sc_selected |>
+  # make a column for each pitch type
+  mutate(pitch_type = as.character(pitch_type)) |>
+  group_by(pitcher, fld_winning, inning, inning_topbot, outs_when_up, balls, strikes) |>
+  drop_na() |>
+  count(pitch_type) |>
+  pivot_wider(names_from = pitch_type, names_prefix = "n_", values_from = n) |>
+  # fill in missing values for columns starting with n_
+  mutate(across(starts_with("n_"), ~ ifelse(is.na(.x), 0, .x))) |>
+  # make a variable n_total that is the total of all columns prefixed with n_
+  mutate(n_total = rowSums(across(starts_with("n_"))))
 
-pitcher_pitchtypes <- sc_down |>
-  drop_na(pitch_type) |>
-  count(pitch_type)
-  
+write.csv(pitcher_pitchtypes, "data/pitcher_pitchtypes.csv")
+
+# assuming a normal distribution for pitch speed by type, independent of other factors
+pitcher_speed <- sc_selected |>
+  group_by(pitcher, pitch_type) |>
+  drop_na(pitch_type, effective_speed) |>
+  summarize(
+    speed_mean = mean(effective_speed),
+    speed_std_dev = sd(effective_speed)
+  )
+
+write.csv(pitcher_speed, "data/pitcher_speed.csv")

--- a/simulator/data_process.R
+++ b/simulator/data_process.R
@@ -1,0 +1,7 @@
+library(tidyverse)
+
+sc <- read.csv('data/statcast.csv')
+
+sc_selected <- sc |> select(pitch_type, zone, type, bb_type, effective_speed, pitcher, batter, bat_score, fld_score, balls, strikes, outs_when_up, inning, inning_topbot)
+
+write.csv(sc_selected, 'data/sc_selected.csv')


### PR DESCRIPTION
This PR adds code to create two tables, `pitcher_pitchtype`, which can be used to determine what pitch a pitcher will throw in a given situation, and `pitcher_pitchspeed` which gives a normal distribution for the speed of those pitches.